### PR TITLE
Make CI run all tests in the workspace

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,7 +6,7 @@ fix:
   cargo clippy --workspace --all-targets --all-features --fix --allow-dirty --allow-staged  -- -D warnings
 
 test:
-  cargo test --all --all-features
+  cargo test --workspace --all-features
 
 # Start up the servers for manual testing
 manual:

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -29,7 +29,7 @@ macro_rules! from_maybe_i64 {
     };
 }
 
-async fn connection(settings: &Settings) -> Result<Client> {
+pub async fn connection(settings: &Settings) -> Result<Client> {
     let log_safe_params = format!(
         "host={} port={} user={} dbname={}",
         settings.database_host,

--- a/nix/pkgs/lightning-knd.nix
+++ b/nix/pkgs/lightning-knd.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage ({
   nativeBuildInputs = [ pkg-config bitcoind cockroachdb teos ] ++ lib.optionals enableLint [ clippy ];
 
   doCheck = enableTests;
-  checkFlags = [
+  cargoTestFlags = [
     "--workspace"
     "--all-features"
     "--all-targets"

--- a/nix/pkgs/lightning-knd.nix
+++ b/nix/pkgs/lightning-knd.nix
@@ -32,7 +32,11 @@ rustPlatform.buildRustPackage ({
   nativeBuildInputs = [ pkg-config bitcoind cockroachdb teos ] ++ lib.optionals enableLint [ clippy ];
 
   doCheck = enableTests;
-
+  checkFlags = [
+    "--workspace"
+    "--all-features"
+    "--all-targets"
+  ];
   meta = with lib; {
     description = "HA Bitcoin Lightning Node";
     homepage = "https://github.com/kuutamoaps/lightning-knd";

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -29,9 +29,8 @@ impl TestSettingsBuilder {
         self
     }
 
-    pub fn for_database(mut self, database: &CockroachManager) -> TestSettingsBuilder {
+    pub fn with_database(mut self, database: &CockroachManager) -> TestSettingsBuilder {
         self.settings.database_port = database.port.to_string();
-        self.settings.database_name = "test".to_string();
         self
     }
 
@@ -53,12 +52,6 @@ impl Default for TestSettingsBuilder {
 
 pub fn test_settings() -> Settings {
     TestSettingsBuilder::default().build()
-}
-
-pub fn test_settings_for_database(database: &CockroachManager) -> Settings {
-    TestSettingsBuilder::default()
-        .for_database(database)
-        .build()
 }
 
 pub fn random_public_key() -> PublicKey {


### PR DESCRIPTION
Realised that some tests do actually need to create new databases so I added a function to do that. And CI didn't catch this because only root package tests were run by default. So now we run all in the workspace.