### PR TITLE
WIP: workaround for is_first_start

### DIFF
--- a/database/src/ldk_database.rs
+++ b/database/src/ldk_database.rs
@@ -72,7 +72,7 @@ impl LdkDatabase {
             .client
             .read()
             .await
-            .query_opt("SELECT true FROM channel_manager", &[])
+            .query_opt("SELECT true FROM channel_manager LIMIT 1", &[])
             .await?
             .is_none())
     }
@@ -251,7 +251,7 @@ impl LdkDatabase {
             .await
             .query_one(
                 "SELECT manager \
-            FROM channel_manager",
+            FROM channel_manager LIMIT 1",
                 &[],
             )
             .await?;


### PR DESCRIPTION
I somehow have two rows in there:

```
root@:26257/lightning_knd> SELECT true FROM channel_manager;
  bool
--------
  true
  true
(2 rows)

Time: 5.294235ms
```

This the the result of `root@:26257/lightning_knd> select * from channel_manager;`:

```
W230202 17:05:25.614667 1 cli/sql.go:248  cannot save command-line history: write_history: operation not permitted
             timestamp             |                                                                                                                                                                                                                                                                                                                                                                                                                                                       manager
-----------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  2023-02-02 16:03:39.298384+00:00 | \001\001o\342\214\012\266\361\263r\301\246\242F\256c\367O\223\036\203e\341Z\010\234h\326\031\000\000\000\000\000\000\000\000\000o\342\214\012\266\361\263r\301\246\242F\256c\367O\223\036\203e\341Z\010\234h\326\031\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000q\001\002\000\000\003\002\000\000\005!\003\015T)\226 \311B\232\256\312\245\272W\207\322Z\007F\277\326t.fo\232\324\003D\355\371\244z\007 #\366\357\355\2063\342\370\0170\300\252\371$\273\316\304\237\332\271\324\375\205\324\321\033=\220\2652\362c\011\000\013 \354\007\021\016\305q\031\317\216\374y\251\315m&\033\377\204\220\267$\267\336\000W\342\326k\256\221\203\260
  2023-02-02 16:03:39.732975+00:00 | \001\001o\342\214\012\266\361\263r\301\246\242F\256c\367O\223\036\203e\341Z\010\234h\326\031\000\000\000\000\000\000\000\000\000o\342\214\012\266\361\263r\301\246\242F\256c\367O\223\036\203e\341Z\010\234h\326\031\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000q\001\002\000\000\003\002\000\000\005!\003\015T)\226 \311B\232\256\312\245\272W\207\322Z\007F\277\326t.fo\232\324\003D\355\371\244z\007 #\366\357\355\2063\342\370\0170\300\252\371$\273\316\304\237\332\271\324\375\205\324\321\033=\220\2652\362c\011\000\013 \354\007\021\016\305q\031\317\216\374y\251\315m&\033\377\204\220\267$\267\336\000W\342\326k\256\221\203\260
(2 rows)
```

The patches I posted are just a workaround, but I have the feeling there shouldn't be 2 channel-manager in the first place.


This is the error I get without them:

```
Feb 02 16:46:28 eve lightning-knd[2100818]: Error: Failed to start ldk controller                
Feb 02 16:46:28 eve lightning-knd[2100818]: Caused by:                                           
Feb 02 16:46:28 eve lightning-knd[2100818]:     0: failed to query channel manage from database  
Feb 02 16:46:28 eve lightning-knd[2100818]:     1: query returned an unexpected number of rows   
```