### PR TITLE
pkgs/cockroachdb: init at 22.2.3

### DIFF
--- a/nix/pkgs/cockroachdb.nix
+++ b/nix/pkgs/cockroachdb.nix
@@ -1,5 +1,22 @@
-{ cockroachdb }:
-cockroachdb.overrideAttrs (old: {
-  # avoid having to deal with unfree license check overlays...
-  meta = old.meta // { license = [ ]; };
-})
+{ stdenv, fetchurl, autoPatchelfHook, lib }:
+stdenv.mkDerivation rec {
+  pname = "cockroachdb";
+  version = "22.2.3";
+  src = fetchurl {
+    url = "https://binaries.cockroachdb.com/cockroach-v${version}.linux-amd64.tgz";
+    sha256 = "sha256-CHuk4lYf6YQiOmcAcjkHuzL3PW/o55G99a5JjbKF4NY=";
+  };
+  buildInputs = [ stdenv.cc.cc ];
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  installPhase = ''
+    install -D -m755 cockroach $out/bin/cockroach
+    cp -r lib $out/lib
+  '';
+  meta = with lib; {
+    homepage = "https://www.cockroachlabs.com";
+    description = "A scalable, survivable, strongly-consistent SQL database";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ mic92 ];
+  };
+}


### PR DESCRIPTION
nixpkgs version is lacking behind. They switched to bazel but not in a good way. Everything including the go compiler and even bazel is now downloaded at buildtime which makes hermetic build's really complex.

This is the second best option to not having to run an outdated cockroachdb.