### PR TITLE
Revert "cockroachdb: pass self to module"

### DIFF
--- a/nix/modules/flake-module.nix
+++ b/nix/modules/flake-module.nix
@@ -23,7 +23,6 @@
       cockroachdb = { pkgs, ... }: {
         imports = [ ./cockroachdb.nix ];
         kuutamo.cockroachdb.package = self.packages.${pkgs.hostPlatform.system}.cockroachdb;
-        _module.args.self = self;
       };
 
       kld-ctl = { config, pkgs, ... }:


### PR DESCRIPTION
Reverts kuutamolabs/lightning-knd#320

error: The option `_module.args.self' is defined multiple times while it's expected to be unique.