### PR TITLE
Remove boot.loader.grub version

### DIFF
--- a/nix/modules/hardware.nix
+++ b/nix/modules/hardware.nix
@@ -27,7 +27,6 @@
     # for mdraid 1.1
     boot.loader.grub.extraConfig = "insmod mdraid1x";
     boot.loader.grub.enable = true;
-    boot.loader.grub.version = 2;
     boot.loader.grub.efiSupport = true;
     boot.loader.grub.efiInstallAsRemovable = true;
   };


### PR DESCRIPTION
as warn message shows on install/update to say this should be removed.

```
$ nixos-rebuild dry-activate --flake /tmp/kuutamo-flake.K03Tx6#kld-00 --option accept-flake-config true --target-host root@x --build-host  --use-substitutes --fast
building the system configuration...
trace: warning: The boot.loader.grub.version option does not have any effect anymore, please remove it from your configuration.
```