### PR TITLE
Allow peer port

### DIFF
--- a/nix/modules/kld/default.nix
+++ b/nix/modules/kld/default.nix
@@ -178,7 +178,7 @@ in
       ];
     };
 
-    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ ];
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ 9234 ];
 
     users.users.kld = {
       isSystemUser = true;


### PR DESCRIPTION
Currently, we do not have this port configured in `kld.toml`, so it is hardcoded now. Once we decide to configurable it in `kld.toml`, we can also make this as a config parameter on nix side.