### PR TITLE
Refactor bitcoind manager tests

### DIFF
--- a/kld/tests/bitcoind.rs
+++ b/kld/tests/bitcoind.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Result};
 use bitcoin::Address;
 use kld::bitcoind::bitcoind_interface::BitcoindInterface;
 use lightning::chain::chaininterface::{ConfirmationTarget, FeeEstimator};
@@ -13,50 +13,59 @@ pub async fn test_bitcoind_client() -> Result<()> {
 
     let mut settings = test_settings(&tmp_dir, "client");
     let bitcoind = BitcoinManager::new(&tmp_dir, &mut settings).await?;
-    let client = bitcoind.client.get().context("expected client")?;
     let n_blocks = 3;
-    client
+    bitcoind
+        .client
         .generate_to_address(n_blocks, &Address::from_str(TEST_ADDRESS).unwrap())
         .await?;
 
-    client.wait_for_blockchain_synchronisation().await;
+    bitcoind.client.wait_for_blockchain_synchronisation().await;
 
-    let info = client.get_blockchain_info().await?;
+    let info = bitcoind.client.get_blockchain_info().await?;
     assert_eq!(n_blocks, info.blocks);
 
-    let best_block = client
+    let best_block = bitcoind
+        .client
         .get_best_block()
         .await
         .map_err(|e| anyhow!(e.into_inner()))?;
     assert_eq!(best_block.0, info.best_block_hash);
     assert_eq!(best_block.1, Some(n_blocks as u32));
 
-    let header = client
+    let header = bitcoind
+        .client
         .get_header(&best_block.0, None)
         .await
         .map_err(|e| anyhow!(e.into_inner()))?;
     assert_eq!(header.height, n_blocks as u32);
     assert_eq!(header.chainwork.low_u64(), 8);
 
-    let block = &client
+    let block = &bitcoind
+        .client
         .get_block(&best_block.0)
         .await
         .map_err(|e| anyhow!(e.into_inner()))?;
 
     assert_eq!(
         2000,
-        client.get_est_sat_per_1000_weight(ConfirmationTarget::Background)
+        bitcoind
+            .client
+            .get_est_sat_per_1000_weight(ConfirmationTarget::Background)
     );
     assert_eq!(
         5000,
-        client.get_est_sat_per_1000_weight(ConfirmationTarget::Normal)
+        bitcoind
+            .client
+            .get_est_sat_per_1000_weight(ConfirmationTarget::Normal)
     );
     assert_eq!(
         10000,
-        client.get_est_sat_per_1000_weight(ConfirmationTarget::HighPriority)
+        bitcoind
+            .client
+            .get_est_sat_per_1000_weight(ConfirmationTarget::HighPriority)
     );
 
-    client.poll_for_fee_estimates();
+    bitcoind.client.poll_for_fee_estimates();
 
     match block {
         BlockData::FullBlock(block) => assert_eq!(block.block_hash(), best_block.0),

--- a/test-utils/src/bitcoin_manager.rs
+++ b/test-utils/src/bitcoin_manager.rs
@@ -123,7 +123,6 @@ impl Drop for BitcoinManager<'_> {
         match self.process.try_wait() {
             Ok(Some(status)) => eprintln!("bitcoind exited unexpected, status code: {status}"),
             Ok(None) => {
-                // We do not need to wait bitcoind all the time, we have electrs for our service
                 let _ = Command::new("kill")
                     .arg(self.process.id().to_string())
                     .output();

--- a/test-utils/src/bitcoin_manager.rs
+++ b/test-utils/src/bitcoin_manager.rs
@@ -1,24 +1,26 @@
-use std::{sync::OnceLock, time::Duration};
+use std::marker::PhantomData;
+use std::path::PathBuf;
+use std::time::Duration;
 
-use anyhow::{Context, Result};
-use async_trait::async_trait;
+use anyhow::{bail, Context, Result};
 use bitcoin::Address;
 use kld::bitcoind::BitcoindClient;
 use kld::settings::Settings;
+use std::process::{Child, Command, Stdio};
 use tempfile::TempDir;
+use tokio::time::{sleep_until, Instant};
 
-use crate::{
-    manager::{Check, Manager},
-    ports::get_available_port,
-};
+use crate::ports::get_available_port;
 
 pub struct BitcoinManager<'a> {
-    manager: Manager<'a>,
+    process: Child,
+    phantom: PhantomData<&'a TempDir>,
+    storage_dir: PathBuf,
     pub p2p_port: u16,
     pub rpc_port: u16,
     pub network: String,
     pub settings: Settings,
-    pub client: OnceLock<BitcoindClient>,
+    pub client: BitcoindClient,
 }
 
 impl<'a> BitcoinManager<'a> {
@@ -28,54 +30,79 @@ impl<'a> BitcoinManager<'a> {
     ) -> Result<BitcoinManager<'a>> {
         let p2p_port = get_available_port()?;
         let rpc_port = get_available_port()?;
+        let storage_dir = output_dir
+            .path()
+            .join(&format!("bitcoind_{}", settings.node_id));
+        std::fs::create_dir(&storage_dir)?;
 
-        let manager = Manager::new(output_dir, "bitcoind", &settings.node_id)?;
-        let mut bitcoind = BitcoinManager {
-            manager,
-            p2p_port,
-            rpc_port,
-            network: settings.bitcoin_network.to_string(),
-            settings: settings.clone(),
-            client: OnceLock::new(),
-        };
-        settings.bitcoind_rpc_port = bitcoind.rpc_port;
-        settings.bitcoin_cookie_path = bitcoind.cookie_path();
-        bitcoind.settings.bitcoind_rpc_port = settings.bitcoind_rpc_port;
-        bitcoind.settings.bitcoin_cookie_path = settings.bitcoin_cookie_path.clone();
-        bitcoind
-            .start(BitcoindCheck(bitcoind.settings.clone()))
-            .await?;
-        Ok(bitcoind)
-    }
+        settings.bitcoind_rpc_port = rpc_port;
+        settings.bitcoin_cookie_path =
+            cookie_path(&settings.bitcoin_network.to_string(), &storage_dir);
 
-    pub async fn start(&mut self, check: impl Check) -> Result<()> {
         let args = &[
             "-server",
             "-noconnect",
-            "-rpcthreads=16",
+            "-rpcthreads=1",
             "-listen",
-            &format!("-chain={}", &self.network),
-            &format!("-datadir={}", &self.manager.storage_dir.as_path().display()),
-            &format!("-port={}", &self.p2p_port.to_string()),
-            &format!("-rpcport={}", &self.rpc_port.to_string()),
+            &format!("-chain={}", settings.bitcoin_network),
+            &format!("-datadir={}", storage_dir.display()),
+            &format!("-port={}", p2p_port),
+            &format!("-rpcport={}", rpc_port),
+            // NOTE
+            // Uncomment it for debugging , there is not good reason always log
+            // Will integrate with #619
+            // &format!("-debuglogfile=<file>", storage_dir.join("bitcoind.log").display())
         ];
-        self.manager.start("bitcoind", args, check).await?;
-        self.client
-            .set(BitcoindClient::new(&self.settings).await?)
-            .unwrap_or_default();
-        Ok(())
+
+        let mut process = Command::new("bitcoind")
+            .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .with_context(|| "failed to start bitcoind")?;
+
+        // XXX
+        // Request `call` and `new` of BitcoindClient should be separate functions
+        // It is not `BitcoindConnection`, so it doesn't make sense to have a hidden request in new.
+        // Also the manager is hard to init the client with `bitcoind` at same time.
+        let mut count = 0;
+        while let Err(e) = BitcoindClient::new(settings)
+            .await
+            .with_context(|| "could not connect to bitcoind")
+        {
+            if count > 3 {
+                let _ = process.kill();
+                return Err(e);
+            } else {
+                sleep_until(Instant::now() + Duration::from_secs(1 + count * 3)).await;
+                count += 1;
+            }
+        }
+
+        let mut bitcoind = match BitcoindClient::new(settings).await {
+            Ok(client) => BitcoinManager {
+                process,
+                phantom: PhantomData,
+                storage_dir,
+                p2p_port,
+                rpc_port,
+                network: settings.bitcoin_network.to_string(),
+                settings: settings.clone(),
+                client,
+            },
+            Err(_) => {
+                let _ = process.kill();
+                bail!("fail to make bitcoind client")
+            }
+        };
+        bitcoind.settings.bitcoind_rpc_port = settings.bitcoind_rpc_port;
+        bitcoind.settings.bitcoin_cookie_path = settings.bitcoin_cookie_path.clone();
+
+        Ok(bitcoind)
     }
 
     pub fn cookie_path(&self) -> String {
-        let dir = if self.network == "mainnet" {
-            self.manager.storage_dir.clone()
-        } else {
-            self.manager.storage_dir.join(&self.network)
-        };
-        dir.join(".cookie")
-            .into_os_string()
-            .into_string()
-            .expect("should not use non UTF-8 char in path")
+        cookie_path(&self.network, &self.storage_dir)
     }
 
     pub async fn generate_blocks(
@@ -84,24 +111,50 @@ impl<'a> BitcoinManager<'a> {
         address: &Address,
         delay: bool,
     ) -> Result<()> {
-        let client = self.client.get().context("bitcoind not started")?;
         for _ in 0..n_blocks {
             // Sometimes a delay is needed to make the test more realistic which is expected by LDK.
             if delay {
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
-            client.generate_to_address(1, address).await?;
+            self.client.generate_to_address(1, address).await?;
         }
-        client.wait_for_blockchain_synchronisation().await;
+        self.client.wait_for_blockchain_synchronisation().await;
         Ok(())
     }
 }
 
-pub struct BitcoindCheck(pub Settings);
+#[inline]
+fn cookie_path(network: &String, storage_dir: &PathBuf) -> String {
+    if network == "mainnet" {
+        storage_dir.join(".cookie")
+    } else {
+        storage_dir.join(&network).join(".cookie")
+    }
+    .into_os_string()
+    .into_string()
+    .expect("should not use non UTF-8 char in path")
+}
 
-#[async_trait]
-impl Check for BitcoindCheck {
-    async fn check(&self) -> bool {
-        BitcoindClient::new(&self.0).await.is_ok()
+impl Drop for BitcoinManager<'_> {
+    fn drop(&mut self) {
+        // Report unexpected bitcoind close, try kill the bitcoind process and wait the log
+        match self.process.try_wait() {
+            Ok(Some(status)) => eprintln!("cockroachdb exited unexpected, status code: {status}"),
+            Ok(None) => {
+                let _ = Command::new("kill")
+                    .arg(self.process.id().to_string())
+                    .output();
+                let mut count = 0;
+                while count < 5 {
+                    if let Ok(Some(_)) = self.process.try_wait() {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_secs(1 + count * 3));
+                    count += 1;
+                }
+                self.process.kill().expect("bitcoind couldn't be killed");
+            }
+            Err(_) => panic!("error attempting cockroachdb status"),
+        }
     }
 }

--- a/test-utils/src/electrs_manager.rs
+++ b/test-utils/src/electrs_manager.rs
@@ -33,9 +33,9 @@ impl<'a> ElectrsManager<'a> {
             manager,
             rpc_address: format!("127.0.0.1:{rpc_port}"),
             monitoring_addr: format!("127.0.0.1:{monitoring_port}"),
-            bitcoin_rpc_addr: format!("127.0.0.1:{}", bitcoin_manager.rpc_port),
+            bitcoin_rpc_addr: format!("127.0.0.1:{}", settings.bitcoind_rpc_port),
             bitcoin_p2p_addr: format!("127.0.0.1:{}", bitcoin_manager.p2p_port),
-            bitcoin_cookie_path: bitcoin_manager.cookie_path(),
+            bitcoin_cookie_path: settings.bitcoin_cookie_path.clone(),
             bitcoin_network: settings.bitcoin_network.to_string(),
         };
 


### PR DESCRIPTION
- Do not spawn too much thread in a test. (16 -> 1)
- Drop redundant BitcoindCheck
- Drop redundant setting copies
