### PR TITLE
check cookie brefore electrs start

### DIFF
--- a/nix/modules/electrs.nix
+++ b/nix/modules/electrs.nix
@@ -59,6 +59,10 @@ in
       after = [ "bitcoind${if cfg.bitcoindInstance == "bitcoind" then "" else cfg.bitcoindInstance}.service" ];
       serviceConfig = {
         ExecStartPre = "+${pkgs.writeShellScript "setup" ''
+          until [ -e ${bitcoinCookieDir}/.cookie ]
+          do
+            sleep 10
+          done
           install -m400 -o electrs ${bitcoinCookieDir}/.cookie /var/lib/electrs/.cookie
         ''}";
         ExecStart = ''


### PR DESCRIPTION
fix #661
Wait for the cookie in `ExecStartPre`, the status of the service will in `activating` not `failed`.  And it will be managed by systems `TimeoutStartSec`. (default 20s)