### PR TITLE
Default no root access

### DIFF
--- a/mgr/src/install.rs
+++ b/mgr/src/install.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use lazy_static::lazy_static;
 use log::info;
+use std::env::var;
 use std::path::Path;
 use std::sync::Mutex;
 use std::{
@@ -105,8 +106,8 @@ pub fn install(
                 .status()
                 .context("Failed to run ssh-keygen to remove old keys...")?;
 
-            loop {
-                // After unlock the sshd will start in port 22
+            // With root access, we check sshd start in port 22
+            while var("FLAKE_CHECK").is_ok() || var("DEBUG").is_ok() {
                 if timeout_ssh(host, &["exit", "0"], true)?.status.success() {
                     break;
                 }

--- a/nix/modules/db-toml-mapping.nix
+++ b/nix/modules/db-toml-mapping.nix
@@ -19,8 +19,9 @@ in
     kuutamo.disko.disks = cfg.disks;
     kuutamo.disko.bitcoindDisks = cfg.bitcoind_disks;
     kuutamo.disko.networkInterface = cfg.network_interface or "eth0";
+    kuutamo.disko.unlockKeys = cfg.public_ssh_keys;
 
-    users.extraUsers.root.openssh.authorizedKeys.keys = cfg.public_ssh_keys;
+    users.extraUsers.root.openssh.authorizedKeys.keys = if (cfg ? keep_root && cfg.keep_root) then cfg.public_ssh_keys else [ "" ];
 
     kuutamo.network.macAddress = cfg.mac_address or null;
 

--- a/nix/modules/hardware.nix
+++ b/nix/modules/hardware.nix
@@ -11,6 +11,11 @@
     default = "eth0";
     description = lib.mdDoc "The network interface for internet";
   };
+  options.kuutamo.disko.unlockKeys = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [ ];
+    description = lib.mdDoc "Ssh key to login locked machines";
+  };
 
   imports = [
     ./raid-config.nix
@@ -53,7 +58,7 @@
       ssh = {
         enable = true;
         port = 2222;
-        authorizedKeys = config.users.extraUsers.root.openssh.authorizedKeys.keys;
+        authorizedKeys = config.kuutamo.disko.unlockKeys;
         hostKeys = [
           "/var/lib/secrets/sshd_key"
         ];

--- a/nix/modules/kld-toml-mapping.nix
+++ b/nix/modules/kld-toml-mapping.nix
@@ -26,8 +26,9 @@ in
     kuutamo.disko.disks = cfg.disks;
     kuutamo.disko.bitcoindDisks = cfg.bitcoind_disks;
     kuutamo.disko.networkInterface = cfg.network_interface or "eth0";
+    kuutamo.disko.unlockKeys = cfg.public_ssh_keys;
 
-    users.extraUsers.root.openssh.authorizedKeys.keys = cfg.public_ssh_keys;
+    users.extraUsers.root.openssh.authorizedKeys.keys = if (cfg ? keep_root && cfg.keep_root) then cfg.public_ssh_keys else [ "" ];
 
     kuutamo.network.macAddress = cfg.mac_address or null;
 

--- a/nix/modules/tests/test-flake/db-00.toml
+++ b/nix/modules/tests/test-flake/db-00.toml
@@ -18,6 +18,7 @@ bitcoind_disks = []
 telegraf_has_monitoring = false
 telegraf_config_hash = "13646096770106105413"
 network_interface = "eth1"
+keep_root = true
 
 [[cockroach_peers]]
 name = "db-00"

--- a/nix/modules/tests/test-flake/db-01.toml
+++ b/nix/modules/tests/test-flake/db-01.toml
@@ -18,6 +18,7 @@ bitcoind_disks = []
 telegraf_has_monitoring = false
 telegraf_config_hash = "13646096770106105413"
 network_interface = "eth1"
+keep_root = true
 
 [[cockroach_peers]]
 name = "db-00"

--- a/nix/modules/tests/test-flake/kld-00.toml
+++ b/nix/modules/tests/test-flake/kld-00.toml
@@ -19,6 +19,7 @@ telegraf_has_monitoring = false
 telegraf_config_hash = "13646096770106105413"
 kld_node_alias = "kld-00-alias"
 network_interface = "eth1"
+keep_root = true
 
 [[cockroach_peers]]
 name = "db-00"


### PR DESCRIPTION
There is no root access for default deployment(the first deployment), only if `FLAKE_CHECK` or `DEBUG` is set, the root access will allow.

No matter whether root access is allowed or not, the root access of `initrd` is still allowed such that the user can unlock the disk.